### PR TITLE
Correcting typos in file name and a function name

### DIFF
--- a/s2wav/dimension-helper-functions.py
+++ b/s2wav/dimension-helper-functions.py
@@ -22,7 +22,7 @@ def sampling_mw_ss_nphi(L: int) -> int:
 
 
 
-def ampling_mw_nphi(L: int) -> int:
+def sampling_mw_nphi(L: int) -> int:
     '''Computes the number of phi samples for McEwen and Wiaux sampling.
     
     Args:

--- a/s2wav/dimension-helper-functions.py
+++ b/s2wav/dimension-helper-functions.py
@@ -118,7 +118,7 @@ def j_max(L: int, lam: float) -> int:
     Returns:
         j_max (int): The maximum wavelet scale used.
     '''
-    return math.ceil(log(L) / log(lam))
+    return math.ceil(math.log(L) / math.log(lam))
 
 
 


### PR DESCRIPTION
One of the functions had a typo in its definition. Updating that so no errors arise when calling upon the function later on.