### PR TITLE
Add vectorised filters and specific tiling functions

### DIFF
--- a/s2wav/filters.py
+++ b/s2wav/filters.py
@@ -53,13 +53,13 @@ def filters_axisym(
     psi = np.zeros((J + 1, L), np.float64)
     phi = np.zeros(L, np.float64)
     for l in range(L):
-        phi[l] = np.sqrt(k[l + J_min * L])
+        phi[l] = np.sqrt(k[J_min, l])
 
     for j in range(J_min, J + 1):
         for l in range(L):
-            diff = k[l + (j + 1) * L] - k[l + j * L]
+            diff = k[j + 1, l] - k[j, l]
             if diff < 0:
-                psi[l + j * L] = previoustemp
+                psi[j, l] = previoustemp
             else:
                 temp = np.sqrt(diff)
                 psi[j, l] = temp
@@ -74,7 +74,7 @@ def filters_directional(
     J_min: int = 0,
     lam: float = 2.0,
     spin: int = 0,
-    original_spin: int = 0,
+    spin0: int = 0,
 ) -> Tuple[np.ndarray, np.ndarray]:
     r"""Generates the harmonic coefficients for the directional tiling wavelets.
 
@@ -92,7 +92,7 @@ def filters_directional(
 
         spin (int, optional): Spin (integer) to perform the transform. Defaults to 0.
 
-        original_spin (int, optional): Spin number the wavelet was lowered from. Defaults to 0.
+        spin0 (int, optional): Spin number the wavelet was lowered from. Defaults to 0.
 
     Returns:
         Tuple[np.ndarray, np.ndarray]: Tuple of wavelet and scaling kernels (:math:`\Psi^j_{\el n}`, :math:`\Phi_{\el m}`)
@@ -103,35 +103,116 @@ def filters_directional(
         [1] J. McEwen et. al., "Directional spin wavelets on the sphere", arXiv preprint arXiv:1509.06749 (2015).
     """
     J = samples.j_max(L, lam)
-    el_min = max(abs(spin), abs(original_spin))
+    el_min = max(abs(spin), abs(spin0))
 
     phi = np.zeros(L, dtype=np.float64)
-    psi = np.zeros((J + 1, L * L), dtype=np.complex128)
+    psi = np.zeros((J + 1, L, 2 * L - 1), dtype=np.complex128)
 
     kappa, kappa0 = filters_axisym(L, J_min, lam)
     s_elm = tiling.tiling_direction(L, N)
 
     for el in range(el_min, L):
-        phi[el] = np.sqrt((2 * el + 1) / (4.0 * np.pi)) * kappa0[el]
-        if original_spin != 0:
-            phi[el] *= (
-                tiling.spin_normalization(el, original_spin) * (-1) ** original_spin
-            )
+        if kappa0[el] != 0:
+            phi[el] = np.sqrt((2 * el + 1) / (4.0 * np.pi)) * kappa0[el]
+            if spin0 != 0:
+                phi[el] *= tiling.spin_normalization(el, spin0) * (-1) ** spin0
 
     for j in range(J_min, J + 1):
-        ind = el_min * el_min
         for el in range(el_min, L):
-            for m in range(-el, el + 1):
-                psi[j, ind] = (
-                    np.sqrt((2 * el + 1) / (8.0 * np.pi * np.pi))
-                    * kappa[j, el]
-                    * s_elm[ind]
-                )
-                if original_spin != 0:
-                    psi[j, ind] *= (
-                        tiling.spin_normalization(el, original_spin)
-                        * (-1) ** original_spin
-                    )
-                ind += 1
+            if kappa[j, el] != 0:
+                for m in range(-el, el + 1):
+                    if s_elm[el, L - 1 + m] != 0:
+                        psi[j, el, L - 1 + m] = (
+                            np.sqrt((2 * el + 1) / (8.0 * np.pi * np.pi))
+                            * kappa[j, el]
+                            * s_elm[el, L - 1 + m]
+                        )
+                        if spin0 != 0:
+                            psi[j, el, L - 1 + m] *= (
+                                tiling.spin_normalization(el, spin0)
+                                * (-1) ** spin0
+                            )
 
     return psi, phi
+
+
+def filters_axisym_vectorised(
+    L: int, J_min: int = 0, lam: float = 2.0
+) -> Tuple[np.ndarray, np.ndarray]:
+    r"""Vectorised version of :func:`~filters_axisym`.
+
+    Args:
+        L (int): Harmonic band-limit.
+
+        J_min (int, optional): Lowest frequency wavelet scale to be used. Defaults to 0.
+
+        lam (float, optional): Wavelet parameter which determines the scale factor
+            between consecutive wavelet scales. Note that :math:`\lambda = 2` indicates
+            dyadic wavelets. Defaults to 2.
+
+    Raises:
+        ValueError: J_min is negative or greater than J.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: Unnormalised wavelet kernels :math:`\Psi^j_{\el m}`
+        with shape :math:`[(J+1)*L], and scaling kernel :math:`\Phi_{\el m}` with shape
+        :math:`[L]` in harmonic space.
+    """
+    k = kernels.k_lam(L, lam)
+    diff = (np.roll(k, -1, axis=0) - k)[:-1]
+    diff[diff < 0] = 0
+    return np.sqrt(diff), np.sqrt(k[J_min])
+
+
+def filters_directional_vectorised(
+    L: int,
+    N: int = 1,
+    J_min: int = 0,
+    lam: float = 2.0,
+    spin: int = 0,
+    spin0: int = 0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    r"""Vectorised version of :func:`~filters_directional`.
+
+    Args:
+        L (int): Harmonic band-limit.
+
+        N (int, optional): Upper azimuthal band-limit. Defaults to 1.
+
+        J_min (int, optional): Lowest frequency wavelet scale to be used. Defaults to 0.
+
+        lam (float, optional): Wavelet parameter which determines the scale factor between
+            consecutive wavelet scales.Note that :math:`\lambda = 2` indicates dyadic
+            wavelets. Defaults to 2.
+
+        spin (int, optional): Spin (integer) to perform the transform. Defaults to 0.
+
+        spin0 (int, optional): Spin number the wavelet was lowered from. Defaults to 0.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: Tuple of wavelet and scaling kernels (:math:`\Psi^j_{\el n}`, :math:`\Phi_{\el m}`)
+            psi (np.ndarray): Harmonic coefficients of directional wavelets with shape :math:`[L^2(J+1)]`.
+            phi (np.ndarray): Harmonic coefficients of scaling function with shape :math:`[L]`.
+    """
+    el_min = max(abs(spin), abs(spin0))
+
+    spin_norms = (
+        (-1) ** spin0
+        * tiling.spin_normalization_vectorised(np.arange(L), spin0)
+        if spin0 != 0
+        else 1
+    )
+
+    kappa, kappa0 = filters_axisym_vectorised(L, J_min, lam)
+    s_elm = tiling.tiling_direction(L, N)
+
+    kappa0 *= np.sqrt((2 * np.arange(L) + 1) / (4.0 * np.pi))
+    kappa0 = kappa0 * spin_norms if spin0 != 0 else kappa0
+
+    kappa *= np.sqrt((2 * np.arange(L) + 1) / 8.0) / np.pi
+    kappa = np.einsum("ij,jk->ijk", kappa, s_elm)
+    kappa = kappa * spin_norms if spin0 != 0 else kappa
+
+    kappa0[:el_min] = 0
+    kappa[:, :el_min, :] = 0
+    return kappa, kappa0

--- a/s2wav/filters.py
+++ b/s2wav/filters.py
@@ -158,6 +158,15 @@ def filters_axisym_vectorised(
         with shape :math:`[(J+1)*L], and scaling kernel :math:`\Phi_{\el m}` with shape
         :math:`[L]` in harmonic space.
     """
+    J = samples.j_max(L, lam)
+
+    if J_min >= J or J_min < 0:
+        raise ValueError(
+            "J_min must be non-negative and less than J= "
+            + str(J)
+            + " for given L and lam."
+        )
+
     k = kernels.k_lam(L, lam)
     diff = (np.roll(k, -1, axis=0) - k)[:-1]
     diff[diff < 0] = 0
@@ -182,7 +191,7 @@ def filters_directional_vectorised(
         J_min (int, optional): Lowest frequency wavelet scale to be used. Defaults to 0.
 
         lam (float, optional): Wavelet parameter which determines the scale factor between
-            consecutive wavelet scales.Note that :math:`\lambda = 2` indicates dyadic
+            consecutive wavelet scales. Note that :math:`\lambda = 2` indicates dyadic
             wavelets. Defaults to 2.
 
         spin (int, optional): Spin (integer) to perform the transform. Defaults to 0.

--- a/s2wav/kernels.py
+++ b/s2wav/kernels.py
@@ -1,5 +1,76 @@
 import numpy as np
-from s2wav import tiling, samples
+import math
+from s2wav import samples
+
+
+def tiling_integrand(t: float, lam: float = 2.0) -> float:
+    r"""Tiling integrand for scale-discretised wavelets `[1] <https://arxiv.org/pdf/1211.1680.pdf>`_.
+
+    Intermediate step used to compute the wavelet and scaling function generating
+    functions. One of the basic mathematical functions needed to carry out the tiling of
+    the harmonic space.
+
+    Args:
+        t (float): Real argument over which we integrate.
+
+        lam (float, optional): Wavelet parameter which determines the scale factor
+            between consecutive wavelet scales.Note that :math:`\lambda = 2` indicates
+            dyadic wavelets. Defaults to 2.
+
+    Returns:
+        float: Value of tiling integrand for given :math:`t` and scaling factor.
+
+    Note:
+        [1] B. Leidstedt et. al., "S2LET: A code to perform fast wavelet analysis on
+            the sphere", A&A, vol. 558, p. A128, 2013.
+    """
+    s_arg = (t - (1 / lam)) * (2.0 * lam / (lam - 1)) - 1
+
+    integrand = np.exp(-2.0 / (1.0 - s_arg**2.0)) / t
+
+    return integrand
+
+
+def part_scaling_fn(a: float, b: float, n: int, lam: float = 2.0) -> float:
+    r"""Computes integral used to calculate smoothly decreasing function :math:`k_{\lambda}`.
+
+    Intermediate step used to compute the wavelet and scaling function generating
+    functions. Uses the trapezium method to integrate :func:`~tiling_integrand` in the
+    limits from :math:`a \rightarrow b` with scaling parameter :math:`\lambda`. One of
+    the basic mathematical functions needed to carry out the tiling of the harmonic
+    space.
+
+    Args:
+        a (float): Lower limit of the numerical integration.
+
+        b (float): Upper limit of the numerical integration.
+
+        n (int): Number of steps to be performed during integration.
+
+        lam (float, optional): Wavelet parameter which determines the scale factor
+            between consecutive wavelet scales.Note that :math:`\lambda = 2` indicates
+            dyadic wavelets. Defaults to 2.
+
+    Returns:
+        float: Integral of the tiling integrand from :math:`a \rightarrow b`.
+    """
+    sum = 0.0
+    h = (b - a) / n
+
+    if a == b:
+        return 0
+
+    for i in range(n):
+        if a + i * h not in [1 / lam, 1.0] and a + (i + 1) * h not in [
+            1 / lam,
+            1.0,
+        ]:
+            f1 = tiling_integrand(a + i * h, lam)
+            f2 = tiling_integrand(a + (i + 1) * h, lam)
+
+            sum += ((f1 + f2) * h) / 2
+
+    return sum
 
 
 def k_lam(L: int, lam: float = 2.0, quad_iters: int = 300) -> float:
@@ -9,45 +80,53 @@ def k_lam(L: int, lam: float = 2.0, quad_iters: int = 300) -> float:
 
     .. math::
 
-        k_{\lambda} \equiv \frac{ \int_t^1 \frac{\text{d}t^{\prime}}{t^{\prime}} s_{\lambda}^2(t^{\prime})}{ \int_{\frac{1}{\lambda}}^1 \frac{\text{d}t^{\prime}}{t^{\prime}} s_{\lambda}^2(t^{\prime})},
+        k_{\lambda} \equiv \frac{ \int_t^1 \frac{\text{d}t^{\prime}}{t^{\prime}}
+        s_{\lambda}^2(t^{\prime})}{ \int_{\frac{1}{\lambda}}^1
+        \frac{\text{d}t^{\prime}}{t^{\prime}} s_{\lambda}^2(t^{\prime})},
 
     where the integrand is defined to be
 
     .. math::
 
-        s_{\lambda} \equiv s \Big ( \frac{2\lambda}{\lambda - 1}(t-\frac{1}{\lambda}) - 1 \Big ),
+        s_{\lambda} \equiv s \Big ( \frac{2\lambda}{\lambda - 1}(t-\frac{1}{\lambda})
+        - 1 \Big ),
 
     for infinitely differentiable Cauchy-Schwartz function :math:`s(t) \in C^{\infty}`.
 
     Args:
         L (int): Harmonic band-limit.
 
-        lam (float, optional): Wavelet parameter which determines the scale factor between consecutive wavelet scales.
-            Note that :math:`\lambda = 2` indicates dyadic wavelets. Defaults to 2.
+        lam (float, optional): Wavelet parameter which determines the scale factor
+            between consecutive wavelet scales.Note that :math:`\lambda = 2` indicates
+            dyadic wavelets. Defaults to 2.
 
-        quad_iters (int, optional): Total number of iterations for quadrature integration. Defaults to 300.
+        quad_iters (int, optional): Total number of iterations for quadrature
+            integration. Defaults to 300.
 
     Returns:
-        (np.ndarray): Value of :math:`k_{\lambda}` computed for values between :math:`\frac{1}{\lambda}` and 1, parametrised by :math:`\el` as required to compute the axisymmetric filters in :func:`~tiling_axisym`.
+        (np.ndarray): Value of :math:`k_{\lambda}` computed for values between
+            :math:`\frac{1}{\lambda}` and 1, parametrised by :math:`\el` as required to
+            compute the axisymmetric filters in :func:`~tiling_axisym`.
 
     Note:
-        [1] B. Leidstedt et. al., "S2LET: A code to perform fast wavelet analysis on the sphere", A&A, vol. 558, p. A128, 2013.
+        [1] B. Leidstedt et. al., "S2LET: A code to perform fast wavelet analysis on the
+            sphere", A&A, vol. 558, p. A128, 2013.
     """
 
     J = samples.j_max(L, lam)
 
-    normalisation = tiling.part_scaling_fn(1 / lam, 1.0, quad_iters, lam)
-    k = np.zeros((J + 2) * L)
+    normalisation = part_scaling_fn(1 / lam, 1.0, quad_iters, lam)
+    k = np.zeros((J + 2, L))
 
     for j in range(J + 2):
         for l in range(L):
             if l < lam ** (j - 1):
-                k[l + j * L] = 1
+                k[j, l] = 1
             elif l > lam**j:
-                k[l + j * L] = 0
+                k[j, l] = 0
             else:
-                k[l + j * L] = (
-                    tiling.part_scaling_fn(l / lam**j, 1.0, quad_iters, lam)
+                k[j, l] = (
+                    part_scaling_fn(l / lam**j, 1.0, quad_iters, lam)
                     / normalisation
                 )
 

--- a/s2wav/kernels.py
+++ b/s2wav/kernels.py
@@ -97,7 +97,7 @@ def k_lam(L: int, lam: float = 2.0, quad_iters: int = 300) -> float:
         L (int): Harmonic band-limit.
 
         lam (float, optional): Wavelet parameter which determines the scale factor
-            between consecutive wavelet scales.Note that :math:`\lambda = 2` indicates
+            between consecutive wavelet scales. Note that :math:`\lambda = 2` indicates
             dyadic wavelets. Defaults to 2.
 
         quad_iters (int, optional): Total number of iterations for quadrature

--- a/s2wav/shapes.py
+++ b/s2wav/shapes.py
@@ -27,15 +27,16 @@ def f_wav(
     Args:
         L (int): Harmonic bandlimit.
 
-        N (int, optional): Upper orientational band-limit. Only flmn with :math:`n < N` will be stored.
-            Defaults to 1.
+        N (int, optional): Upper orientational band-limit. Defaults to 1.
 
         J_min (int, optional): Lowest frequency wavelet scale to be used. Defaults to 0.
 
-        lam (float, optional): Wavelet parameter which determines the scale factor between consecutive wavelet scales.
-            Note that :math:`\lambda = 2` indicates dyadic wavelets. Defaults to 2.
+        lam (float, optional): Wavelet parameter which determines the scale factor between
+            consecutive wavelet scales. Note that :math:`\lambda = 2` indicates dyadic
+            wavelets. Defaults to 2.
 
-        sampling (str, optional): Spherical sampling scheme from {"mw","mwss"}. Defaults to "mw".
+        sampling (str, optional): Spherical sampling scheme from {"mw","mwss"}.
+            Defaults to "mw".
 
     Returns:
         Tuple[int, int, int,int]: Wavelet coefficients shape :math:`[n_{J}, n_{N}, L^2]`.
@@ -49,36 +50,36 @@ def f_wav(
     )
 
 
-def flm_scal(L: int) -> int:
+def flm_scal(L: int) -> Tuple[int, int]:
     r"""Returns the shape of scaling coefficients in harmonic space.
 
     Args:
         L (int): Harmonic bandlimit.
 
     Returns:
-        int: Scaling coefficients shape :math:`[L^2]`.
+        Tuple[int,int]: Scaling coefficients shape :math:`[L, 2*L-1]`.
     """
-    return L * L
+    return L, 2 * L - 1
 
 
 def flmn_wav(
     L: int, N: int = 1, J_min: int = 0, lam: float = 2.0
-) -> Tuple[int, int, int]:
+) -> Tuple[int, int, int, int]:
     """Returns the shape of wavelet coefficients in Wigner space.
 
     Args:
         L (int): Harmonic bandlimit.
 
-        N (int, optional): Upper orientational band-limit. Only flmn with :math:`n < N` will be stored.
-            Defaults to 1.
+        N (int, optional): Upper orientational band-limit. Defaults to 1.
 
         J_min (int, optional): Lowest frequency wavelet scale to be used. Defaults to 0.
 
-        lam (float, optional): Wavelet parameter which determines the scale factor between consecutive wavelet scales.
-            Note that :math:`\lambda = 2` indicates dyadic wavelets. Defaults to 2.
+        lam (float, optional): Wavelet parameter which determines the scale factor between
+            consecutive wavelet scales. Note that :math:`\lambda = 2` indicates dyadic
+            wavelets. Defaults to 2.
 
     Returns:
-        Tuple[int, int, int]: Wavelet coefficients shape :math:`[n_{J}, n_{N}, L^2]`.
+        Tuple[int, int, int, int]: Wavelet coefficients shape :math:`[n_{J}, n_{N}, L, 2L-1]`.
     """
     J = samples.j_max(L, lam)
-    return (J - J_min + 1), (2 * N - 1), L * L
+    return (J - J_min + 1), (2 * N - 1), L, 2 * L - 1

--- a/s2wav/shapes.py
+++ b/s2wav/shapes.py
@@ -14,7 +14,7 @@ def f_scal(L: int, sampling: str = "mw") -> Tuple[int, int]:
         sampling (str, optional): Spherical sampling scheme from {"mw","mwss"}. Defaults to "mw".
 
     Returns:
-        Tuple[int,int]: Scaling coefficients shape :math:`[n_{\theta}, n_{\phi}]`.
+        Tuple[int, int]: Scaling coefficients shape :math:`[n_{\theta}, n_{\phi}]`.
     """
     return samples.ntheta(L, sampling), samples.nphi(L, sampling)
 
@@ -39,7 +39,7 @@ def f_wav(
             Defaults to "mw".
 
     Returns:
-        Tuple[int, int, int,int]: Wavelet coefficients shape :math:`[n_{J}, n_{N}, L^2]`.
+        Tuple[int, int, int, int]: Wavelet coefficients shape :math:`[n_{J}, n_{N}, L^2]`.
     """
     J = samples.j_max(L, lam)
     return (
@@ -57,7 +57,7 @@ def flm_scal(L: int) -> Tuple[int, int]:
         L (int): Harmonic bandlimit.
 
     Returns:
-        Tuple[int,int]: Scaling coefficients shape :math:`[L, 2*L-1]`.
+        Tuple[int, int]: Scaling coefficients shape :math:`[L, 2*L-1]`.
     """
     return L, 2 * L - 1
 

--- a/s2wav/tiling.py
+++ b/s2wav/tiling.py
@@ -2,97 +2,31 @@ import numpy as np
 from s2wav.math_utils import binomial_coefficient
 
 
-def tiling_integrand(t: float, lam: float = 2.0) -> float:
-    r"""Tiling integrand for scale-discretised wavelets `[1] <https://arxiv.org/pdf/1211.1680.pdf>`_.
-
-    Intermediate step used to compute the wavelet and scaling function generating functions. One of the basic mathematical functions needed to carry out the tiling of the harmonic space.
-
-    Args:
-        t (float): Real argument over which we integrate.
-
-        lam (float, optional): Wavelet parameter which determines the scale factor between consecutive wavelet scales.
-            Note that :math:`\lambda = 2` indicates dyadic wavelets. Defaults to 2.
-
-    Returns:
-        float: Value of tiling integrand for given :math:`t` and scaling factor.
-
-    Note:
-        [1] B. Leidstedt et. al., "S2LET: A code to perform fast wavelet analysis on the sphere", A&A, vol. 558, p. A128, 2013.
-    """
-    s_arg = (t - (1 / lam)) * (2.0 * lam / (lam - 1)) - 1
-
-    integrand = np.exp(-2.0 / (1.0 - s_arg**2.0)) / t
-
-    return integrand
-
-
-def part_scaling_fn(a: float, b: float, n: int, lam: float = 2.0) -> float:
-    r"""Computes integral used to calculate smoothly decreasing function :math:`k_{\lambda}`.
-
-    Intermediate step used to compute the wavelet and scaling function generating functions. Uses the trapezium method to integrate :func:`~tiling_integrand` in the limits from :math:`a \rightarrow b` with scaling parameter :math:`\lambda`. One of the basic mathematical functions needed to carry out the tiling of the harmonic space.
-
-    Args:
-        a (float): Lower limit of the numerical integration.
-
-        b (float): Upper limit of the numerical integration.
-
-        n (int): Number of steps to be performed during integration.
-
-        lam (float, optional): Wavelet parameter which determines the scale factor between consecutive wavelet scales.
-            Note that :math:`\lambda = 2` indicates dyadic wavelets. Defaults to 2.
-
-    Raises:
-        TypeError: If :math:`n` is not of type integer
-
-    Returns:
-        float: Integral of the tiling integrand from :math:`a \rightarrow b`.
-    """
-
-    if not isinstance(n, int) == True:
-        raise TypeError("n must be an integer")
-
-    sum = 0.0
-    h = (b - a) / n
-
-    if a == b:
-        return 0
-
-    else:
-        for i in range(n):
-            if a + i * h not in [1 / lam, 1.0] and a + (i + 1) * h not in [
-                1 / lam,
-                1.0,
-            ]:
-                f1 = tiling_integrand(a + i * h, lam)
-                f2 = tiling_integrand(a + (i + 1) * h, lam)
-
-                sum += ((f1 + f2) * h) / 2
-
-    return sum
-
-
 def tiling_direction(L: int, N: int = 1) -> np.ndarray:
-    r"""Generates the harmonic coefficients for the directionality component of the tiling functions.
+    r"""Generates the harmonic coefficients for the directionality component of the
+        tiling functions.
 
     Formally, this function implements the follow equation
 
     .. math::
 
-        _{s}\eta_{\el m} = \nu \vu \sqrt{\frac{1}{2^{\gamma}} \big ( \binom{\gamma}{(\gamma - m)/2} \big )}
+        _{s}\eta_{\el m} = \nu \vu \sqrt{\frac{1}{2^{\gamma}} \big ( \binom{\gamma}{
+                (\gamma - m)/2} \big )}
 
     which was first derived in `[1] <https://arxiv.org/pdf/1211.1680.pdf>`_.
 
     Args:
         L (int): Harmonic band-limit.
 
-        N (int, optional): Upper orientational band-limit. Only flmn with :math:`n < N` will be stored.
-            Defaults to 1.
+        N (int, optional): Upper orientational band-limit. Defaults to 1.
 
     Returns:
-        np.ndarray: Harmonic coefficients of directionality components :math:`_{s}\eta_{\el m}`.
+        np.ndarray: Harmonic coefficients of directionality components
+            :math:`_{s}\eta_{\el m}`.
 
     Notes:
-        [1] J. McEwen et. al., "Directional spin wavelets on the sphere", arXiv preprint arXiv:1509.06749 (2015).
+        [1] J. McEwen et. al., "Directional spin wavelets on the sphere", arXiv preprint
+            arXiv:1509.06749 (2015).
     """
     if N % 2:
         nu = 1
@@ -101,7 +35,7 @@ def tiling_direction(L: int, N: int = 1) -> np.ndarray:
 
     ind = 1
 
-    s_elm = np.zeros(L * L, dtype=np.complex128)
+    s_elm = np.zeros((L, 2 * L - 1), dtype=np.complex128)
 
     for el in range(1, L):
         if (N + el) % 2:
@@ -111,11 +45,12 @@ def tiling_direction(L: int, N: int = 1) -> np.ndarray:
 
         for m in range(-el, el + 1):
             if abs(m) < N and (N + m) % 2:
-                s_elm[ind] = nu * np.sqrt(
-                    (binomial_coefficient(gamma, ((gamma - m) / 2))) / (2**gamma)
+                s_elm[el, L - 1 + m] = nu * np.sqrt(
+                    (binomial_coefficient(gamma, ((gamma - m) / 2)))
+                    / (2**gamma)
                 )
             else:
-                s_elm[ind] = 0.0
+                s_elm[el, L - 1 + m] = 0.0
 
             ind += 1
 
@@ -123,7 +58,8 @@ def tiling_direction(L: int, N: int = 1) -> np.ndarray:
 
 
 def spin_normalization(el: int, spin: int = 0) -> float:
-    r"""Computes the normalization factor for spin-lowered wavelets, which is :math:`\sqrt{\frac{(l+s)!}{(l-s)!}}`.
+    r"""Computes the normalization factor for spin-lowered wavelets, which is
+        :math:`\sqrt{\frac{(l+s)!}{(l-s)!}}`.
 
     Args:
         el (int): Harmonic index :math:`\el`.
@@ -133,7 +69,7 @@ def spin_normalization(el: int, spin: int = 0) -> float:
     Returns:
         float: Normalization factor for spin-lowered wavelets.
     """
-    factor = 1
+    factor = 1.0
 
     for s in range(-abs(spin) + 1, abs(spin) + 1):
         factor *= el + s
@@ -142,3 +78,21 @@ def spin_normalization(el: int, spin: int = 0) -> float:
         return np.sqrt(factor)
     else:
         return np.sqrt(1.0 / factor)
+
+
+def spin_normalization_vectorised(el: np.ndarray, spin: int = 0) -> float:
+    r"""Vectorised version of :func:`~spin_normalization`.
+
+    Args:
+        el (int): Harmonic index :math:`\el`.
+
+        spin (int): Spin of field over which to perform the transform. Defaults to 0.
+
+    Returns:
+        float: Normalization factor for spin-lowered wavelets.
+    """
+    factor = np.arange(-abs(spin) + 1, abs(spin) + 1).reshape(
+        1, 2 * abs(spin) + 1
+    )
+    factor = el.reshape(len(el), 1).dot(factor)
+    return np.sqrt(np.prod(factor, axis=1) ** (np.sign(spin)))

--- a/s2wav/tiling.py
+++ b/s2wav/tiling.py
@@ -33,8 +33,6 @@ def tiling_direction(L: int, N: int = 1) -> np.ndarray:
     else:
         nu = 1j
 
-    ind = 1
-
     s_elm = np.zeros((L, 2 * L - 1), dtype=np.complex128)
 
     for el in range(1, L):
@@ -51,8 +49,6 @@ def tiling_direction(L: int, N: int = 1) -> np.ndarray:
                 )
             else:
                 s_elm[el, L - 1 + m] = 0.0
-
-            ind += 1
 
     return s_elm
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -19,7 +19,14 @@ def test_synthesis(wavelet_generator, L: int, N: int, J_min: int, lam: int):
     f_wav, f_scal = wavelet_generator(L=L, N=N, J_min=J_min, lam=lam)
 
     f = s2let.synthesis_wav2px(
-        f_wav.flatten("C"), f_scal.flatten("C"), lam, L, J_min, N, 0, upsample=True
+        f_wav.flatten("C"),
+        f_scal.flatten("C"),
+        lam,
+        L,
+        J_min,
+        N,
+        0,
+        upsample=True,
     )
     f_check = synthesis.synthesis_transform(f_wav, f_scal, L, N, J_min, lam)
 


### PR DESCRIPTION
This PR just vectorises the functions which generate directional and axisymmetric filters. The rate limiting step for the directional functions is the computation of the kernels `k_lam` however this relates to the quadrature integration we wish to replace so for now this implementation should be sufficient.

Basic `%timeit` tests show minimal improvement in speed which isn't too surprising as the implementation evaluates many unnecessary values (for `el` values outside of the `j` wavelet support) to be easily vectorised. Moreover, the filter generating functions are a **very minor** contribution to the overall transform wall-time so probably not wasting effort here (for now). 