### PR TITLE
add support for lower-bound acceleration

### DIFF
--- a/docs/api/utility/index.rst
+++ b/docs/api/utility/index.rst
@@ -16,7 +16,7 @@ Utility Functions
      - Computes the number of :math:`\theta` samples.
    * - :func:`~s2wav.utils.samples.j_bandlimit`
      - Computes the band-limit of a specific wavelet scale.
-   * - :func:`~s2wav.utils.samples.L0`
+   * - :func:`~s2wav.utils.shapes.L0_j`
      - Computes the minimum harmonic index supported by the given wavelet scale :math:`j`.
    * - :func:`~s2wav.utils.samples.n_px`
      - Returns the number of spherical pixels for a given sampling scheme.

--- a/s2wav/transforms/synthesis.py
+++ b/s2wav/transforms/synthesis.py
@@ -64,12 +64,12 @@ def synthesis_transform_looped(
     # Sum the all wavelet wigner coefficients for each lmn
     # Note that almost the entire compute is concentrated at the highest J
     for j in range(J_min, J + 1):
-        Lj, Nj = shapes.LN_j(L, j, N, lam, multiresolution)
+        Lj, Nj, L0j = shapes.LN_j(L, j, N, lam, multiresolution)
         temp = base.wigner.forward(
-            f_wav[j - J_min], Lj, Nj, 0, sampling, reality, nside
+            f_wav[j - J_min], Lj, Nj, L0j, sampling, reality, nside
         )
         for n in range(-Nj + 1, Nj, 2):
-            for el in range(max(abs(spin), abs(n)), Lj):
+            for el in range(max(abs(spin), abs(n), L0j), Lj):
                 psi = wav_lm[j, el, L - 1 + n]
                 for m in range(-el, el + 1):
                     flm[el, L - 1 + m] += temp[Nj - 1 + n, el, Lj - 1 + m] * psi
@@ -152,14 +152,14 @@ def synthesis_transform_vectorised(
     # Sum the all wavelet wigner coefficients for each lmn
     # Note that almost the entire compute is concentrated at the highest J
     for j in range(J_min, J + 1):
-        Lj, Nj = shapes.LN_j(L, j, N, lam, multiresolution)
+        Lj, Nj, L0j = shapes.LN_j(L, j, N, lam, multiresolution)
         temp = base.wigner.forward(
-            f_wav[j - J_min], Lj, Nj, 0, sampling, reality, nside
+            f_wav[j - J_min], Lj, Nj, L0j, sampling, reality, nside
         )
-        flm[:Lj, L - Lj : L - 1 + Lj] += np.einsum(
+        flm[L0j:Lj, L - Lj : L - 1 + Lj] += np.einsum(
             "ln,nlm->lm",
-            wav_lm[j, :Lj, L - Nj : L - 1 + Nj : 2],
-            temp[::2, :, :],
+            wav_lm[j, L0j:Lj, L - Nj : L - 1 + Nj : 2],
+            temp[::2, L0j:, :],
         )
 
     # Sum the all scaling harmonic coefficients for each lm

--- a/s2wav/utils/samples.py
+++ b/s2wav/utils/samples.py
@@ -71,29 +71,6 @@ def j_bandlimit(j: int, lam: float = 2.0, kernel: str = "s2dw") -> int:
         raise ValueError(f"Kernel type {kernel} not supported!")
 
 
-def L0(j: int, lam: float = 2.0, kernel: str = "s2dw") -> int:
-    r"""Computes the minimum harmonic index supported by the given wavelet scale :math:`j`.
-
-    Args:
-        j (int): Wavelet scale to consider.
-
-        lam (float, optional): Wavelet parameter which determines the scale factor between consecutive wavelet scales.
-            Note that :math:`\lambda = 2` indicates dyadic wavelets. Defaults to 2.
-
-        kernel (str, optional): The wavelet type from {"s2dw"}. Defaults to "s2dw".
-
-    Raises:
-        ValueError: Kernel type not supported.
-
-    Returns:
-        int: The minimum harmonic multipole :math:`el` which is supported by a given wavelet scale.
-    """
-    if kernel.lower() == "s2dw":
-        return np.ceil(lam ** (j - 1))
-    else:
-        raise ValueError(f"Kernel type {kernel} not supported!")
-
-
 def j_max(L: int, lam: float = 2.0) -> int:
     r"""Computes needlet maximum level required to ensure exact reconstruction.
 
@@ -225,9 +202,13 @@ def n_lmn_wav(
                 sampling_flmn_size = (2 * N - 1) * el * el
         elif storage.lower() == "compact":
             if reality:
-                sampling_flmn_size = N * (6 * el * el - (N - 1) * (2 * N - 1)) / 6
+                sampling_flmn_size = (
+                    N * (6 * el * el - (N - 1) * (2 * N - 1)) / 6
+                )
             else:
-                sampling_flmn_size = (2 * N - 1) * (3 * el * el - N * (N - 1)) / 3
+                sampling_flmn_size = (
+                    (2 * N - 1) * (3 * el * el - N * (N - 1)) / 3
+                )
         else:
             raise ValueError(f"Storage method {storage} not recognised.")
 

--- a/s2wav/utils/shapes.py
+++ b/s2wav/utils/shapes.py
@@ -97,6 +97,24 @@ def n_wav_scales(L: int, N: int = 1, J_min: int = 0, lam: float = 2.0) -> int:
     return samples.j_max(L, lam) - J_min + 1
 
 
+def L0_j(j: int, lam: float = 2.0) -> int:
+    r"""Computes the minimum harmonic index supported by the given wavelet scale :math:`j`.
+
+    Args:
+        j (int): Wavelet scale to consider.
+
+        lam (float, optional): Wavelet parameter which determines the scale factor between consecutive wavelet scales.
+            Note that :math:`\lambda = 2` indicates dyadic wavelets. Defaults to 2.
+
+    Raises:
+        ValueError: Kernel type not supported.
+
+    Returns:
+        int: The minimum harmonic multipole :math:`el` which is supported by a given wavelet scale.
+    """
+    return math.ceil(lam ** (j - 1))
+
+
 def LN_j(
     L: int,
     j: int = 0,
@@ -127,11 +145,12 @@ def LN_j(
         int: Total number of wavelet scales :math:`n_{j}`.
     """
     Lj = wav_j_bandlimit(L, j, lam, multiresolution)
+    L0j = L0_j(j, lam)
     Nj = N
     if multiresolution:
         Nj = min(N, Lj)
         Nj += (Nj + N) % 2
-    return Lj, Nj
+    return Lj, Nj, L0j
 
 
 def f_wav_j(
@@ -175,7 +194,7 @@ def f_wav_j(
         wavelet coefficients are stored as a list of arrays, this being the shape of
         one array within such a list.
     """
-    Lj, Nj = LN_j(L, j, N, lam, multiresolution)
+    Lj, Nj, _ = LN_j(L, j, N, lam, multiresolution)
 
     return so3_samples.f_shape(Lj, Nj, sampling, nside)
 
@@ -332,7 +351,7 @@ def flmn_wav_j(
         wavelet coefficients are stored as a list of arrays, this being the shape of
         one array within such a list.
     """
-    Lj, Nj = LN_j(L, j, N, lam, multiresolution)
+    Lj, Nj, _ = LN_j(L, j, N, lam, multiresolution)
     return 2 * Nj - 1, Lj, 2 * Lj - 1
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,10 +44,10 @@ def generate_f_wav_scal(
 
     f_wav = []
     for j in range(J_min, J + 1):
-        Lj, Nj = shapes.LN_j(L, j, N, lam, multiresolution)
+        Lj, Nj, L0j = shapes.LN_j(L, j, N, lam, multiresolution)
 
         for n in range(-Nj + 1, Nj, 2):
-            for el in range(abs(n), Lj):
+            for el in range(max(abs(n), L0j), Lj):
                 for m in range(-el, el + 1):
                     flmn[j - J_min][Nj - 1 + n, el, Lj - 1 + m] = (
                         rng.uniform() + 1j * rng.uniform()


### PR DESCRIPTION
Wavelet filters at scale `j` have both a lower and upper limits for their harmonic support. We already supported the upper limit but this PR adds support for the lower limit. For multi-resolution (which should be used in almost any case) the compute is dominated by the highest scale, where the minimum band limit is half of this.  

Given the way `S2FFT` handles the transform this saves us both a factor of 2 compute and memory. However, this PR only capitalises on the factor 2 compute (as `S2FFT` only exploits this for acceleration rather than memory efficiency).